### PR TITLE
llama: enable tensor split for bailingmoe3 + nemotron_h_moe

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1067,7 +1067,9 @@ bool llm_arch_supports_sm_tensor(const llm_arch & arch) {
         case LLM_ARCH_BITNET:
         case LLM_ARCH_T5:
         case LLM_ARCH_NEMOTRON_H:
-        case LLM_ARCH_NEMOTRON_H_MOE:
+        // NEMOTRON_H_MOE is deliberately absent: the fork runs it under -sm tensor via
+        // llm_arch_sm_tensor_replicates_attention (design A). Do not re-add it.
+        // Dense NEMOTRON_H stays gated - no routed experts, pure mirror loss.
         case LLM_ARCH_GRANITE_HYBRID:
         // MINIMAX_M2 is deliberately absent: the fork supports it under -sm tensor.
         // Do not re-add it. LFM2/LFM2MOE were dropped from this list by upstream.
@@ -1099,6 +1101,11 @@ bool llm_arch_sm_tensor_replicates_attention(const llm_arch & arch) {
         // falls through to the mirrored default, keeping expert selection
         // bit-identical across lanes.
         case LLM_ARCH_BAILINGMOE3:
+        // nemotron_h_moe interleaves mamba2 and attention blocks with routed experts.
+        // The mamba conv/recurrent state cannot be row-split and the attention adds
+        // little mass, so everything but the experts mirrors (design A); expert reads
+        // dominate this arch's per-token traffic, which is what the split targets.
+        case LLM_ARCH_NEMOTRON_H_MOE:
             return true;
         default:
             return false;

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1075,7 +1075,8 @@ bool llm_arch_supports_sm_tensor(const llm_arch & arch) {
         case LLM_ARCH_MINIMAX_M3:
         case LLM_ARCH_MISTRAL4:
         case LLM_ARCH_KIMI_LINEAR:
-        case LLM_ARCH_BAILINGMOE3:
+        // BAILINGMOE3 is deliberately absent: the fork runs it under -sm tensor via
+        // llm_arch_sm_tensor_replicates_attention (design A). Do not re-add it.
         case LLM_ARCH_KIMI_K3:
         case LLM_ARCH_QWEN3TTS:
             return false;
@@ -1091,6 +1092,13 @@ bool llm_arch_sm_tensor_replicates_attention(const llm_arch & arch) {
         case LLM_ARCH_DEEPSEEK2:
         case LLM_ARCH_DEEPSEEK32:
         case LLM_ARCH_DEEPSEEK4:
+        // bailingmoe3 pairs the same single-latent MLA attention with gated-delta-net
+        // layers whose conv/recurrent state cannot be row-split either, so everything
+        // except the routed experts mirrors per lane. The generic ffn(_exps)/shexp
+        // patterns already cover its MoE tensor names, and the router (ffn_gate_inp)
+        // falls through to the mirrored default, keeping expert selection
+        // bit-identical across lanes.
+        case LLM_ARCH_BAILINGMOE3:
             return true;
         default:
             return false;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -844,6 +844,12 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             const uint32_t n_gqa    = hparams.n_gqa(il);
             const uint32_t n_embd_q = n_gqa * hparams.n_embd_head_k(il);
 
+            // Hybrid archs whose loaders leave the per-layer attention counts zeroed
+            // (e.g. nemotron_h_moe) still route non-recurrent tensors like ffn_exps
+            // through here; with n_gqa == 0 there is no Q/KV semantics to scale by,
+            // so fall through to the shared expert/FFN rules below instead of
+            // dividing by zero.
+            if (n_gqa > 0 && n_embd_q > 0) {
             // to handle head sizes like 80, only increase granularity while it doesn't cause underutilization
             int64_t blck_size_perf = blck_size;
             while (blck_size_perf < 128 && blck_size_perf*ud->n_devices < n_embd_q) {
@@ -897,6 +903,7 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
                 GGML_ASSERT(segments.size() == 2);
                 return {granularity_q, granularity_kv};
             }
+            } // n_gqa > 0 && n_embd_q > 0
         }
 
         // Shared expert. It splits on the same axes as the routed FFN, so it needs a


### PR DESCRIPTION
Two hybrid MoE arches — bailingmoe3 and nemotron_h_moe — were gated behind `LLAMA_SPLIT_MODE_TENSOR not implemented`. This series flips that gate for both, using design A (mirror the non-expert stacks, split the routed experts through the existing ffn_exps rules).

The third commit is a crash fix that only surfaced once nemotron_h_moe was enabled: hybrid loaders zero out per-layer attention hparams on non-attention blocks, but `blk.N.ffn_down_exps` on those blocks still hits the regular-attention granularity path and divides `granularity_q / n_gqa` where both are zero. SIGFPE at load. Skipping the Q/KV granularity math when the layer has no attention dims fixes it — those tensors fall through to the shared expert/FFN rules unchanged.

Three commits, +24/-2 across `src/llama-arch.cpp` and `src/llama-model.cpp`. No new per-tensor routing rules needed for either arch.

**Validation** — 2× MI50 gfx906, ROCm 7.14, greedy 35-task suite:

Ling-3.0-tiny Q8_0 (bailingmoe3):
| mode | accuracy | notes |
|---|---|---|
| `-sm layer`, repack off | 33/35 | baseline |
| `-sm tensor`, repack off | 33/35 | exact parity, kernel log clean |
| `-sm tensor`, repack ON | 33/35 | layer-split Q8_0 repack corruption doesn't reproduce on the staged TP load path |

Nemotron-3.5-Lightning-30B-A3B Q4_0 (nemotron_h_moe):
| mode | dec tok/s @2048 c1 | accuracy |
|---|---|---|
| `-sm layer` | 348.5 | 34/35 |
| `-sm tensor` | 317.9 | 33/35 |
| `-sm tensor`, CUSTOM_AR=1 + SHEXP_SPLIT=1 | 329.0 | (accuracy on untuned config) |

Zero amdgpu page faults across every TP run. The ±1 task deltas are within the run-to-run noise floor on this rig (greedy + GPU kernel nondeterminism).

**Performance honesty:** on these two GPUs the speed story depends on the workload. Synthetic `tg128` @2048c1 shows tensor slightly slower than layer (317.9 vs 348.5 tok/s) — per-block PCIe AllReduce plus mirrored non-expert compute outweighs halved expert reads at 2 lanes. But on the real 16K OMP prompt (8934 tok, `HBM 1170` OC) tensor **wins 120 vs 75 tok/s (+59%)** with `LLAMA_NEMOTRON_GQA_TP=1` sharding attention heads — the GQA head-split halves HBM traffic and the KV quant (Q4_0) leaves cache for ngram tables. The env knobs (`CUSTOM_AR=1`, `SHEXP_SPLIT=1`) recover another few percent on synthetic. The win profile scales with more lanes (expert read shrinks as 1/N, mirror cost is constant), RCCL/peer-copy fabrics, and models where expert mass dominates. Correctness-wise both arches now have a working tensor-split mode that's byte-consistent with their layer baseline to within scoring noise.
